### PR TITLE
 Make lifish installable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,3 +255,19 @@ if(MSYS)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mwindows")
 	endif()
 endif()
+
+# Installation
+if (MSVC)
+	install(TARGETS ${PROJECT_NAME} DESTINATION lifish)
+	set(LIFISH_ASSETS_PARENT_DIR lifish)
+else()
+	install(TARGETS ${PROJECT_NAME} DESTINATION bin)
+	set(LIFISH_ASSETS_PARENT_DIR "usr/share/lifish")
+endif()
+install(DIRECTORY assets DESTINATION ${LIFISH_ASSETS_PARENT_DIR})
+file(TO_NATIVE_PATH "${LIFISH_ASSETS_PARENT_DIR}/assets" LIFISH_ASSETS_DIR)
+install(FILES levels.json DESTINATION ${LIFISH_ASSETS_DIR})
+
+include_directories(${CMAKE_BINARY_DIR})
+file(TO_NATIVE_PATH "src/lifish/conf/config.in" CONFIG_FILE)
+configure_file(${CONFIG_FILE} config.h) # requires LIFISH_ASSETS_PARENT_DIR

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -1,3 +1,4 @@
+#include "config.h"
 #include "core.hpp"
 #include "GameCache.hpp"
 #include "Options.hpp"
@@ -106,7 +107,7 @@ bool lif::initCore() {
 
 	// Fill the assetDir variable once and for all
 	std::stringstream ss;
-	ss << pwd << DIRSEP << "assets" << DIRSEP;
+	ss << pwd << DIRSEP << ".." << DIRSEP << LIFISH_ASSETS_DIR << DIRSEP;
 	assetDir = ss.str();
 
 	return true;

--- a/src/lifish/conf/config.in
+++ b/src/lifish/conf/config.in
@@ -1,0 +1,3 @@
+#pragma once
+
+#cmakedefine LIFISH_ASSETS_DIR "@LIFISH_ASSETS_DIR@" 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,7 @@
 #include "Time.hpp"
 #include "UI.hpp"
 #include "WinLoseHandler.hpp"
+#include "config.h"
 #include "contexts.hpp"
 #include "game.hpp"
 #include <SFML/Window.hpp>
@@ -221,7 +222,7 @@ int main(int argc, char **argv) {
 	if (args.mute_music)
 		lif::options.musicVolume = 0;
 	if (args.levelset_name.length() < 1)
-		args.levelset_name = std::string(lif::pwd) + lif::DIRSEP + std::string("levels.json");
+		args.levelset_name = std::string(lif::pwd) + lif::DIRSEP + ".." + lif::DIRSEP + LIFISH_ASSETS_DIR + lif::DIRSEP + "levels.json";
 
 	// Create the game window
 	lif::options.windowSize = sf::Vector2u(lif::WINDOW_WIDTH, lif::WINDOW_HEIGHT);


### PR DESCRIPTION
Assets and levels.json are copied to the install directory.

With these changes it won't be possible to build lifish from the source directory anymore:
`levels.json` will be expected to be found in the assets directory, and not at the same level as the `lifish` binary.