### PR TITLE
Add missing <stdexcept> header for std::invalid_argument

### DIFF
--- a/src/core/debug/Counter.cpp
+++ b/src/core/debug/Counter.cpp
@@ -1,5 +1,6 @@
 #include "Counter.hpp"
 #include <exception>
+#include <stdexcept>
 
 using lif::debug::Counter;
 

--- a/src/core/debug/TimeStats.cpp
+++ b/src/core/debug/TimeStats.cpp
@@ -1,5 +1,6 @@
 #include "TimeStats.hpp"
 #include <exception>
+#include <stdexcept>
 
 using lif::debug::TimeStats;
 


### PR DESCRIPTION
This header fixes an error that prevents compiling the code successfully on Linux.