### PR TITLE
Default to Command keys on macOS to place a bomb

### DIFF
--- a/src/lifish/controls.cpp
+++ b/src/lifish/controls.cpp
@@ -7,14 +7,22 @@ std::array<sf::Keyboard::Key, lif::controls::CONTROLS_NUM> lif::controls::player
 		/* Control::DOWN, */ sf::Keyboard::Key::Down,
 		/* Control::LEFT, */ sf::Keyboard::Key::Left,
 		/* Control::RIGHT,*/ sf::Keyboard::Key::Right,
+#if defined(SFML_SYSTEM_MACOS)
+		/* Control::BOMB, */ sf::Keyboard::Key::RSystem
+#else
 		/* Control::BOMB, */ sf::Keyboard::Key::RControl
+#endif
 	}},
 	{{
 		/* Control::UP,    */ sf::Keyboard::Key::W,
 		/* Control::DOWN,  */ sf::Keyboard::Key::S,
 		/* Control::LEFT,  */ sf::Keyboard::Key::A,
 		/* Control::RIGHT, */ sf::Keyboard::Key::D,
+#if defined(SFML_SYSTEM_MACOS)
+		/* Control::BOMB,  */ sf::Keyboard::Key::LSystem
+#else
 		/* Control::BOMB,  */ sf::Keyboard::Key::LControl
+#endif
 	}}
 };
 


### PR DESCRIPTION
Built-in Mac keyboards don't have the Right Control key, so a user would have to change keys before playing for the first time. `{L,R}System` instead is mapped to Command keys (originally named Apple) which is available in both Left and Right.