### PR TITLE
Sort saved games list by lexicographic order

### DIFF
--- a/src/ui/SaveDataBrowser.cpp
+++ b/src/ui/SaveDataBrowser.cpp
@@ -38,6 +38,8 @@ auto SaveDataBrowser::browseSaveData(std::string path) const -> std::vector<Save
 	}
 	closedir(dir);
 
+	std::sort(files.begin(), files.end());
+
 	return files;
 }
 

--- a/src/ui/SaveDataBrowser.hpp
+++ b/src/ui/SaveDataBrowser.hpp
@@ -17,6 +17,10 @@ protected:
 		std::string path;
 		int level = 0;
 		int nPlayers = 0;
+
+		bool operator <(const SaveFile& sf) const {
+			return (displayName < sf.displayName);
+		}
 	};
 
 	SaveDataBrowser();


### PR DESCRIPTION
Instead of the random order returned by `readdir()`