### PR TITLE
Fix preferences and saved games not created when folders already exist

### DIFF
--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -73,6 +73,17 @@ sf::View lif::keepRatio(const sf::Vector2f& size, const sf::Vector2u& designedsi
 }
 
 bool lif::createDirIfNotExisting(const std::filesystem::path& path) {
-	bool ok = std::filesystem::create_directories(path);
-	return ok;
+	std::error_code err_created, err_exists;
+
+	if (!std::filesystem::create_directories(path, err_created)) {
+		// Directory not created
+		if (std::filesystem::exists(path, err_exists)) {
+			// Directory already existing
+			return true;
+		}
+		std::cerr << "[ WARNING ] could not create directory " << path << ". " << err_created.message() << std::endl;
+		return false;
+	}
+
+	return true;
 }

--- a/src/core/utils.hpp
+++ b/src/core/utils.hpp
@@ -226,7 +226,6 @@ void testMusic();
 
 sf::View keepRatio(const sf::Vector2f& size, const sf::Vector2u& designedsize);
 
-/** Note: this will NOT create a directory recursively */
 bool createDirIfNotExisting(const std::filesystem::path& path);
 
 } // end namespace lif

--- a/src/lifish/preferences_persistence.cpp
+++ b/src/lifish/preferences_persistence.cpp
@@ -56,6 +56,8 @@ void lif::savePreferences(std::string fpath) {
 	}
 
 	file << out.dump(8) << "\n";
+
+	std::cerr << "[ INFO ] saved preferences in " << fpath << ".\n";
 }
 
 void lif::loadPreferences(std::string fpath) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -310,9 +310,9 @@ int main(int argc, char **argv) {
 		if (ui.mustSaveGame()) {
 			const auto saveName = ui.getSaveName() + ".lifish";
 			if (lif::SaveManager::saveGame(saveName, game->getLM()))
-				std::cerr << "Saved game in " << saveName << "." << std::endl;
+				std::cerr << "[ INFO ] saved game in " << saveName << "." << std::endl;
 			else
-				std::cerr << "Failed to save game in " << saveName << "." << std::endl;
+				std::cerr << "[ WARNING ] could not save game in " << saveName << "." << std::endl;
 		}
 
 		///// LOGIC LOOP /////


### PR DESCRIPTION
`std::filesystem::create_directory` used in https://github.com/silverweed/lifish/commit/75af9b5dc19a85513a100e3d6708bc305b10e986 returns false in case the directory tree already exists, which means saves and preferences were only created once and never updated again. This pull requests verifies whether false return code was due to the directory tree already existing or an actual error.

https://en.cppreference.com/w/cpp/filesystem/create_directory

