### PR TITLE
Copy .desktop file in place to follow AppDir conventions

### DIFF
--- a/makeapp_linux.sh
+++ b/makeapp_linux.sh
@@ -38,6 +38,7 @@ cmake --build build -j "$(nproc)"
 mkdir -p lifish.AppDir/usr/{bin,lib,share/applications}
 
 cp -a linux/* lifish.AppDir/
+cp -a linux/*.desktop lifish.AppDir/usr/share/applications/
 cp -a assets/ lifish.AppDir/
 cp -a build/lifish lifish.AppDir/usr/bin/
 


### PR DESCRIPTION
I thought copying the .desktop inside the AppDir root would copy it to /usr/share/applications but apparently it's not, though not picking up the reason why there should be two copies or a link to the root one: https://docs.appimage.org/reference/appdir.html#id3

> Contains desktop files for applications in bin. Normally, there’s just one desktop file in this directory, which is symlinked in the root directory.