### PR TITLE
Add libmd0 and libbsd0 shared objects in AppImage for Batocera.linux compatibility

### DIFF
--- a/makeapp_linux.sh
+++ b/makeapp_linux.sh
@@ -22,8 +22,10 @@ required_libs=(
 	libsfml-system.so.2.5
 	libsfml-window.so.2.5
 
+	libbsd.so.0
 	libFLAC.so.8
 	libfreetype.so.6
+	libmd.so.0
 	libogg.so.0
 	libopenal.so.1
 	libsndio.so.7.0


### PR DESCRIPTION
Not tested on Batocera but should fix https://codeberg.org/silverweed/lifish/issues/11