### PR TITLE
Update runners to Ubuntu 22.04, use official arm64 runners

### DIFF
--- a/.github/workflows/ReleaseBuilds.yml
+++ b/.github/workflows/ReleaseBuilds.yml
@@ -19,7 +19,7 @@ jobs:
           path: BOOM-Remake-*-mac.dmg
 
   build-linux-appimage-x86_64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -38,43 +38,20 @@ jobs:
           path: BOOM-Remake-*-linux-x86_64.AppImage
 
   build-linux-appimage-aarch64:
-    runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    runs-on: ubuntu-22.04-arm
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
         with:
           ref: boom
 
-      - run: mkdir -p artifacts
-
-      - uses: uraimo/run-on-arch-action@v2
-        with:
-          arch: aarch64
-          distro: ubuntu20.04
-          githubToken: ${{ github.token }}
-
-          dockerRunArgs: --volume "${PWD}/artifacts:/artifacts"
-
-          install: |
-            apt update
-            apt install -y build-essential cmake curl libsfml-dev
-
-          run: ./makeapp_linux.sh --prepare-github-actions
-
       - run: |
           sudo apt update
-          sudo apt install -y desktop-file-utils
+          sudo apt install -y desktop-file-utils libsfml-dev
 
-          cd artifacts
-
-          archive_file="$(echo BOOM-Remake-*-linux-aarch64.tar)"
-          appimage_file="${archive_file%.*}.AppImage"
-
-          tar xf "$archive_file"
-
-          ./appimagetool-x86_64.AppImage --runtime-file runtime-aarch64 --no-appstream lifish.AppDir "$appimage_file"
+      - run: ./makeapp_linux.sh
 
       - uses: actions/upload-artifact@v4
         with:
           name: linux-build-aarch64
-          path: artifacts/BOOM-Remake-*-linux-aarch64.AppImage
+          path: BOOM-Remake-*-linux-aarch64.AppImage

--- a/makeapp_linux.sh
+++ b/makeapp_linux.sh
@@ -15,7 +15,7 @@ runtime_version="continuous"
 runtime_filename="runtime-$system_arch"
 runtime_baseurl="https://github.com/AppImage/type2-runtime/releases/download/$runtime_version"
 
-# Shared libraries as of Ubuntu 20.04
+# Shared libraries as of Ubuntu 22.04
 required_libs=(
 	libsfml-audio.so.2.5
 	libsfml-graphics.so.2.5
@@ -45,21 +45,6 @@ cp -a build/lifish lifish.AppDir/usr/bin/
 for lib in "${required_libs[@]}"; do
 	cp -a -L "/lib/$system_arch-linux-gnu/$lib" lifish.AppDir/usr/lib/
 done
-
-if [ "$1" = "--prepare-github-actions" ]; then
-	tar cf "artifacts/BOOM-Remake-$sw_version-linux-$system_arch.tar" lifish.AppDir
-
-	cd artifacts
-
-	appimagetool_filename="appimagetool-x86_64.AppImage"
-	curl -sSf -L -O "$appimagetool_baseurl/$appimagetool_filename"
-	chmod +x "$appimagetool_filename"
-
-	curl -sSf -L -O "$runtime_baseurl/$runtime_filename"
-	chmod +x "$runtime_filename"
-
-	exit 0
-fi
 
 if [ ! -f "$appimagetool_filename" ]; then
 	curl -sSf -L -O "$appimagetool_baseurl/$appimagetool_filename"


### PR DESCRIPTION
Using more recent Ubuntu runner due to GitHub [announcing](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/) the removal of 20.04 on 1/4/2025. Obviously this means less compatibility but Ubuntu 20.04 will loose security support on 2/4/2025 unless users buy the ESM.

I would write in the release notes of a future version that BOOM Remake users will need a Linux version with more recent libc for the AppImage or compile it themselves.

Now that GitHub [announced](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) free Linux arm64 runners for public repositories, the arm64 job doesn't need to use virtualization anymore and it's essentially the same as the x86_64 job. Plus it takes 1-2 minutes instead of more than 15. Also recommend deleting [your cached docker image](https://github.com/silverweed?tab=packages) used by the action. 