### PR TITLE
Use less specific libsndio filename to fix missing shared object

### DIFF
--- a/makeapp_linux.sh
+++ b/makeapp_linux.sh
@@ -28,7 +28,7 @@ required_libs=(
 	libmd.so.0
 	libogg.so.0
 	libopenal.so.1
-	libsndio.so.7.0
+	libsndio.so.7
 	libvorbis.so.0
 	libvorbisenc.so.2
 	libvorbisfile.so.3


### PR DESCRIPTION
The AppImage attempted to use the `libsndio.so.7` shared object but it was included as `libsndio.so.7.0` in the AppDir, which worked when built on Ubuntu 20.04 but not on 22.04. My bad, I didn't notice because I tried to run off the system where it was compiled instead of a clean virtual machine as I usually do.